### PR TITLE
add us web design css, adjust checkbox input to work

### DIFF
--- a/code/upaya/app/assets/stylesheets/application.css.scss
+++ b/code/upaya/app/assets/stylesheets/application.css.scss
@@ -11,6 +11,7 @@
  * file per style scope.
  *
  */
-// @import "us_web_design_standards";
+
+@import "us_web_design_standards";
 @import "us_web_design_standards_fonts";
 @import "utils/spinner";

--- a/code/upaya/app/helpers/devise/two_factor_authentication_setup_helper.rb
+++ b/code/upaya/app/helpers/devise/two_factor_authentication_setup_helper.rb
@@ -6,7 +6,8 @@ module Devise
         item_wrapper_tag: :div, item_wrapper_class: 'flat-checkbox',
         checked: checked_state(f, form_location)
       ) do |b|
-        b.label(for: id_for_2fa_checkbox(b)) { b.check_box(id: id_for_2fa_checkbox(b)) + b.text }
+        id = id_for_2fa_checkbox(b)
+        b.check_box(id: id) + b.label(for: id) { b.text }
       end
     end
 


### PR DESCRIPTION
@monfresh: i figured that checkbox quirkiness -- we were nesting the input within the label and the USWDS wanted the form field to have an input element and then a separate label element following that... I tweaked that form builder helper to reflect that but i'm not sure i did it in the most idiomatic way.