### PR TITLE
Clean up home page views and enable Terms links

### DIFF
--- a/code/upaya/app/controllers/terms_controller.rb
+++ b/code/upaya/app/controllers/terms_controller.rb
@@ -1,0 +1,4 @@
+class TermsController < ApplicationController
+  def index
+  end
+end

--- a/code/upaya/app/views/devise/sessions/_form.html.slim
+++ b/code/upaya/app/views/devise/sessions/_form.html.slim
@@ -8,12 +8,3 @@ p.required.disclaimer-basic
   = f.button :submit, t('upaya.headings.log_in'), class: 'usa-button'
 
 = render 'devise/shared/links'
-
-/.leftalign
-/  p.disclaimer-basic
-/    = link_to t('upaya.headings.passwords.forgot'), new_password_path(resource_name)
-/
-/.rightalign
-/  p.disclaimer-basic
-/    'Don't have an account?
-/    = link_to t('upaya.headings.registrations.new'), new_registration_path(resource_name)

--- a/code/upaya/app/views/devise/sessions/new.html.slim
+++ b/code/upaya/app/views/devise/sessions/new.html.slim
@@ -1,6 +1,5 @@
 - title t('upaya.titles.visitors.index')
 
-
 h2 = t('upaya.headings.log_in')
 = render 'devise/sessions/form'
 
@@ -10,8 +9,8 @@ h2 = t('upaya.headings.visitors.new_account')
 / h5 = t('upaya.forms.session.advantage')
 / ul = t('upaya.forms.session.advantage_list_html')
 
-- if  AppSetting.registrations_enabled?
-  = link_to t('upaya.forms.buttons.new_account'),  new_user_registration_path, class: 'usa-button'
+- if AppSetting.registrations_enabled?
+  = link_to t('upaya.forms.buttons.new_account'), new_user_registration_path, class: 'usa-button'
 - else
   = button_to t('upaya.forms.buttons.no_accounts'), nil, class: "usa-button", tabindex: -1, disabled: true
 

--- a/code/upaya/app/views/devise/shared/_links.html.slim
+++ b/code/upaya/app/views/devise/shared/_links.html.slim
@@ -1,12 +1,9 @@
 .py3
-  / - if controller_name != 'sessions'
-  /   div = link_to 'Log in', new_session_path(resource_name)
-
   - if AppSetting.registrations_enabled? && devise_mapping.registerable? && controller_name != 'sessions'
     div = link_to 'Sign up', new_registration_path(resource_name)
 
   - if devise_mapping.recoverable? && !['passwords','registrations'].include?(controller_name)
-    div = link_to 'Forgot your password?', new_password_path(resource_name)
+    div = link_to t('upaya.headings.passwords.forgot'), new_password_path(resource_name)
 
   - if devise_mapping.confirmable? && controller_name != 'confirmations'
     div = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)

--- a/code/upaya/app/views/shared/_upaya_legal_notice.html.slim
+++ b/code/upaya/app/views/shared/_upaya_legal_notice.html.slim
@@ -3,7 +3,7 @@ div
 div
   = link_to 'Paperwork Reduction Act Reporting Burden', 'terms#pra',  data: { toggle: "modal", target: "#praModal" }, class: 'modalpop'
 div
-  = link_to 'Accessibility Policy', "#{user_signed_in? && user.role != 'user' ?  'http://upaya.18f.gov/pages/accessibility.aspx' : 'http://upaya.18f.gov/accessibility'}",  target: '_blank'
+  = link_to 'Accessibility Policy', 'http://upaya.18f.gov/accessibility',  target: '_blank'
 
 == render 'modals/privacy_statement'
 == render 'modals/pra_statement'

--- a/code/upaya/config/routes.rb
+++ b/code/upaya/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   match '/dashboard' => 'dashboard#index', as: :dashboard_index, via: :get
 
+  get 'terms' => 'terms#index'
+
   # Devise handles login itself. It's first in the chain to avoid a redirect loop during
   # authentication failure.
   devise_for :users, skip: [:sessions], controllers: {
@@ -15,7 +17,6 @@ Rails.application.routes.draw do
     post '/' => 'users/sessions#create', as: :user_session
     delete 'sign_out' => 'users/sessions#destroy', as: :destroy_user_session
 
-    get 'elis' => 'users/sessions#new'
     get 'active'  => 'users/sessions#active'
     get 'timeout' => 'users/sessions#timeout'
 

--- a/code/upaya/spec/features/visitors/home_page_spec.rb
+++ b/code/upaya/spec/features/visitors/home_page_spec.rb
@@ -28,35 +28,6 @@ feature 'Home page' do
     end
   end
 
-  context 'small print' do
-    before(:each) { visit root_path }
-
-    xit 'links to Privacy Act Statement' do
-      click_link 'Privacy Act Statement'
-      expect(page).to have_content('The information and associated')
-      expect(page).to have_link 'www.upaya.gov/privacy', href: 'https://www.upaya.gov/privacy'
-      expect(current_path).to eq terms_path
-    end
-
-    xit 'links to Paperwork Reduction Act Reporting Burden' do
-      click_link 'Paperwork Reduction Act Reporting Burden'
-      expect(page).to have_content 'An agency may not conduct'
-      expect(current_path).to eq terms_path
-    end
-
-    it 'links to Accessibility Policy' do
-      expect(page).
-        to have_link('Accessibility Policy', href: 'http://upaya.18f.gov/accessibility')
-    end
-
-    it 'links to Terms of Use' do
-      skip 'waiting for OMB approval'
-      click_link 'Terms of Use'
-      expect(page).to have_content('Rules of Behavior')
-      expect(current_path).to eq terms_path
-    end
-  end
-
   describe 'navigation links' do
     it 'links to root for Sign In link' do
       visit root_path

--- a/code/upaya/spec/routing/routes_spec.rb
+++ b/code/upaya/spec/routing/routes_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'Routes', type: :routing do
+  before do
+    Rails.application.reload_routes!
+  end
+
+  it 'routes /terms to TermsController' do
+    expect(get: 'terms').to route_to(controller: 'terms', action: 'index')
+  end
+end

--- a/code/upaya/spec/views/devise/sessions/new.html.slim_spec.rb
+++ b/code/upaya/spec/views/devise/sessions/new.html.slim_spec.rb
@@ -1,0 +1,77 @@
+describe 'devise/sessions/new.html.slim' do
+  before do
+    allow(view).to receive(:resource).and_return(build_stubbed(:user))
+    allow(view).to receive(:resource_name).and_return(:user)
+    allow(view).to receive(:devise_mapping).and_return(Devise.mappings[:user])
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title).with(t('upaya.titles.visitors.index'))
+
+    render
+  end
+
+  it 'has a localized h2 headings' do
+    render
+
+    expect(rendered).to have_selector('h2', t('upaya.headings.log_in'))
+    expect(rendered).
+      to have_selector('h2', t('upaya.headings.visitors.new_account'))
+  end
+
+  it 'links to the privacy act statement' do
+    render
+
+    expect(rendered).
+      to have_link(
+        'Privacy Act Statement', href: 'terms#privacy')
+  end
+
+  it 'links to the Paperwork Reduction Act Reporting Burden' do
+    render
+
+    expect(rendered).
+      to have_link(
+        'Paperwork Reduction Act Reporting Burden', href: 'terms#pra')
+  end
+
+  it 'links to Accessibility Policy' do
+    render
+
+    expect(rendered).
+      to have_link(
+        'Accessibility Policy', href: 'http://upaya.18f.gov/accessibility')
+  end
+
+  it 'includes a link to create a new account' do
+    render
+
+    expect(rendered).
+      to have_link(
+        t('upaya.forms.buttons.new_account'), href: new_user_registration_path)
+  end
+
+  it 'renders the modals/_privacy_statement partial' do
+    render
+
+    expect(view).to render_template('modals/_privacy_statement')
+  end
+
+  it 'renders the modals/_pra_statement partial' do
+    render
+
+    expect(view).to render_template('modals/_pra_statement')
+  end
+
+  it 'renders the shared/_privacy_text partial' do
+    render
+
+    expect(view).to render_template('shared/_privacy_text')
+  end
+
+  it 'renders the shared/_pra_text partial' do
+    render
+
+    expect(view).to render_template('shared/_pra_text')
+  end
+end

--- a/code/upaya/spec/views/terms/index.html.slim_spec.rb
+++ b/code/upaya/spec/views/terms/index.html.slim_spec.rb
@@ -1,0 +1,19 @@
+describe 'terms/index.html.slim' do
+  it 'renders the smallprint template' do
+    render
+
+    expect(view).to render_template('terms/_smallprint')
+  end
+
+  it 'renders the shared/_privacy_text partial' do
+    render
+
+    expect(view).to render_template('shared/_privacy_text')
+  end
+
+  it 'renders the shared/_pra_text partial' do
+    render
+
+    expect(view).to render_template('shared/_pra_text')
+  end
+end


### PR DESCRIPTION
- Add missing route and controller for the `/terms` view

- Replace integration specs in home_page_spec with faster view specs

- Remove unnecessary logic in `_upaya_legal_notice` partial. We only
anticipate having one accessibility policy, if we have one at all.

- Remove commented out code, and use localized text in
`devise/shared/_links`

- Remove commented out code from `devise/sessions/_form`

- Minor cleanup of extra whitespace in `devise/sessions/new`

Fixes #14